### PR TITLE
Add main and prod clusters to Argo CD

### DIFF
--- a/ARGOCD_CLUSTER_SETUP.md
+++ b/ARGOCD_CLUSTER_SETUP.md
@@ -1,0 +1,195 @@
+# Adding Main and Prod Clusters to ArgoCD
+
+This guide will help you add your main and prod clusters to your existing ArgoCD installation on the dev cluster.
+
+## Prerequisites
+
+- ArgoCD installed and running on dev cluster
+- Access to main and prod cluster kubeconfig files or contexts
+- kubectl and ArgoCD CLI installed (already done)
+
+## Step-by-Step Instructions
+
+### 1. Verify ArgoCD Installation
+
+First, let's verify that ArgoCD is running on your dev cluster:
+
+```bash
+kubectl get pods -n argocd
+```
+
+You should see pods like:
+- argocd-server
+- argocd-application-controller
+- argocd-dex-server
+- argocd-redis
+- argocd-repo-server
+
+### 2. Get ArgoCD Admin Password
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+```
+
+### 3. Connect to ArgoCD
+
+Set up port forwarding and login:
+
+```bash
+# Port forward ArgoCD server
+kubectl port-forward svc/argocd-server -n argocd 8080:443 &
+
+# Login to ArgoCD (replace <password> with the password from step 2)
+argocd login localhost:8080 --username admin --password <password> --insecure
+```
+
+### 4. Add Clusters to ArgoCD
+
+You have several options to add your clusters:
+
+#### Option A: Using Kubeconfig Files
+
+If you have kubeconfig files for your main and prod clusters:
+
+```bash
+# Add main cluster
+argocd cluster add main --kubeconfig /path/to/main-kubeconfig --server https://main-cluster-server:6443
+
+# Add prod cluster
+argocd cluster add prod --kubeconfig /path/to/prod-kubeconfig --server https://prod-cluster-server:6443
+```
+
+#### Option B: Using Kubectl Contexts
+
+If you have kubectl contexts configured:
+
+```bash
+# Switch to main cluster context
+kubectl config use-context main-cluster-context
+
+# Add main cluster
+argocd cluster add main
+
+# Switch to prod cluster context
+kubectl config use-context prod-cluster-context
+
+# Add prod cluster
+argocd cluster add prod
+```
+
+#### Option C: Using the Provided Scripts
+
+Run the setup script:
+
+```bash
+./add-specific-clusters.sh
+```
+
+### 5. Verify Clusters
+
+List all clusters in ArgoCD:
+
+```bash
+argocd cluster list
+```
+
+You should see:
+- dev (in-cluster)
+- main
+- prod
+
+### 6. Test Cluster Access
+
+Test that ArgoCD can access your clusters:
+
+```bash
+# Test main cluster
+argocd cluster get main
+
+# Test prod cluster
+argocd cluster get prod
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Cluster not accessible**: Ensure the cluster server URL is correct and accessible
+2. **Authentication failed**: Check that the kubeconfig file has valid credentials
+3. **Permission denied**: Ensure the service account has proper RBAC permissions
+
+### RBAC Permissions
+
+For ArgoCD to manage applications on your clusters, the service account needs these permissions:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-manager
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-manager
+subjects:
+- kind: ServiceAccount
+  name: argocd-manager
+  namespace: kube-system
+```
+
+## Next Steps
+
+After successfully adding your clusters:
+
+1. Create applications that can be deployed to different clusters
+2. Set up cluster-specific configurations
+3. Configure cluster-specific policies and constraints
+4. Set up monitoring and logging for multi-cluster deployments
+
+## Useful Commands
+
+```bash
+# List all clusters
+argocd cluster list
+
+# Get cluster details
+argocd cluster get <cluster-name>
+
+# Remove a cluster
+argocd cluster rm <cluster-name>
+
+# Get cluster credentials
+argocd cluster get-credentials <cluster-name>
+
+# List applications
+argocd app list
+
+# Create an application
+argocd app create <app-name> --repo <repo-url> --path <path> --dest-server <cluster-url> --dest-namespace <namespace>
+```
+
+## Security Considerations
+
+1. **Network Security**: Ensure proper network policies between clusters
+2. **RBAC**: Use least privilege principle for service accounts
+3. **Secrets Management**: Use external secret management systems
+4. **Audit Logging**: Enable audit logging for cluster operations
+5. **Encryption**: Ensure data in transit and at rest is encrypted

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# Prayag-new1
-New project 
+# ArgoCD Multi-Cluster Setup
+
+This repository contains scripts and documentation for adding main and prod clusters to your existing ArgoCD installation on the dev cluster.
+
+## Files Overview
+
+- `add-clusters-to-argocd.sh` - Comprehensive script for adding clusters to ArgoCD
+- `add-specific-clusters.sh` - Specific script with detailed instructions
+- `quick-start.sh` - Quick setup and connection test
+- `verify-clusters.sh` - Script to verify cluster connectivity
+- `manual-cluster-addition.md` - Step-by-step manual guide
+- `ARGOCD_CLUSTER_SETUP.md` - Comprehensive documentation
+- `example-cluster-configs.yaml` - Example cluster configurations
+
+## Quick Start
+
+1. **Verify ArgoCD is running:**
+   ```bash
+   kubectl get pods -n argocd
+   ```
+
+2. **Run the quick start script:**
+   ```bash
+   ./quick-start.sh
+   ```
+
+3. **Add your clusters manually:**
+   ```bash
+   # For main cluster
+   argocd cluster add main --kubeconfig /path/to/main-kubeconfig --server https://main-cluster:6443
+   
+   # For prod cluster
+   argocd cluster add prod --kubeconfig /path/to/prod-kubeconfig --server https://prod-cluster:6443
+   ```
+
+4. **Verify clusters:**
+   ```bash
+   ./verify-clusters.sh
+   ```
+
+## Prerequisites
+
+- ArgoCD installed and running on dev cluster
+- Access to main and prod cluster kubeconfig files or contexts
+- kubectl and ArgoCD CLI installed
+
+## Manual Steps
+
+If the automated scripts don't work, follow the manual guide in `manual-cluster-addition.md`.
+
+## Troubleshooting
+
+Common issues and solutions are documented in the individual files. The most common issues are:
+
+1. **Cluster not accessible**: Check cluster server URL and network connectivity
+2. **Authentication failed**: Verify kubeconfig file has valid credentials
+3. **Permission denied**: Ensure proper RBAC permissions are set up
+
+## Next Steps
+
+After successfully adding your clusters:
+
+1. Create applications that can be deployed to different clusters
+2. Set up cluster-specific configurations
+3. Configure cluster-specific policies and constraints
+4. Set up monitoring and logging for multi-cluster deployments
+
+## Support
+
+If you encounter issues, check the troubleshooting sections in the documentation files or refer to the ArgoCD official documentation.

--- a/add-clusters-to-argocd.sh
+++ b/add-clusters-to-argocd.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# Script to add main and prod clusters to ArgoCD
+# This script assumes ArgoCD is already installed on the dev cluster
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to wait for ArgoCD to be ready
+wait_for_argocd() {
+    local namespace=${1:-argocd}
+    print_status "Waiting for ArgoCD to be ready in namespace: $namespace"
+    
+    # Wait for ArgoCD server to be ready
+    kubectl wait --for=condition=available --timeout=300s deployment/argocd-server -n $namespace || {
+        print_error "ArgoCD server is not ready. Please check the ArgoCD installation."
+        exit 1
+    }
+    
+    print_success "ArgoCD is ready!"
+}
+
+# Function to get ArgoCD admin password
+get_argocd_password() {
+    local namespace=${1:-argocd}
+    print_status "Getting ArgoCD admin password..."
+    
+    # Get the admin password
+    ARGOCD_PASSWORD=$(kubectl -n $namespace get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+    
+    if [ -z "$ARGOCD_PASSWORD" ]; then
+        print_error "Could not retrieve ArgoCD admin password. Please check if ArgoCD is properly installed."
+        exit 1
+    fi
+    
+    print_success "ArgoCD admin password retrieved"
+    echo "Admin password: $ARGOCD_PASSWORD"
+}
+
+# Function to login to ArgoCD
+login_to_argocd() {
+    local argocd_server=${1:-argocd-server}
+    local namespace=${2:-argocd}
+    
+    print_status "Logging into ArgoCD..."
+    
+    # Port forward ArgoCD server
+    print_status "Setting up port forwarding for ArgoCD server..."
+    kubectl port-forward svc/$argocd_server -n $namespace 8080:443 &
+    PORT_FORWARD_PID=$!
+    
+    # Wait a moment for port forwarding to establish
+    sleep 5
+    
+    # Login to ArgoCD
+    argocd login localhost:8080 --username admin --password $ARGOCD_PASSWORD --insecure || {
+        print_error "Failed to login to ArgoCD"
+        kill $PORT_FORWARD_PID 2>/dev/null
+        exit 1
+    }
+    
+    print_success "Successfully logged into ArgoCD"
+}
+
+# Function to add a cluster to ArgoCD
+add_cluster_to_argocd() {
+    local cluster_name=$1
+    local cluster_server=$2
+    local kubeconfig_path=$3
+    
+    print_status "Adding cluster '$cluster_name' to ArgoCD..."
+    
+    # Add cluster using kubeconfig
+    argocd cluster add $cluster_name --kubeconfig $kubeconfig_path --yes || {
+        print_error "Failed to add cluster '$cluster_name' to ArgoCD"
+        return 1
+    }
+    
+    print_success "Successfully added cluster '$cluster_name' to ArgoCD"
+}
+
+# Function to list clusters in ArgoCD
+list_argocd_clusters() {
+    print_status "Listing clusters in ArgoCD..."
+    argocd cluster list
+}
+
+# Main execution
+main() {
+    print_status "Starting ArgoCD cluster addition process..."
+    
+    # Check if required commands exist
+    if ! command_exists kubectl; then
+        print_error "kubectl is not installed or not in PATH"
+        exit 1
+    fi
+    
+    if ! command_exists argocd; then
+        print_error "ArgoCD CLI is not installed or not in PATH"
+        exit 1
+    fi
+    
+    # Check if we're connected to a cluster
+    if ! kubectl cluster-info >/dev/null 2>&1; then
+        print_error "Not connected to any Kubernetes cluster. Please configure kubectl first."
+        exit 1
+    fi
+    
+    # Wait for ArgoCD to be ready
+    wait_for_argocd
+    
+    # Get ArgoCD admin password
+    get_argocd_password
+    
+    # Login to ArgoCD
+    login_to_argocd
+    
+    # Add clusters (you'll need to provide the actual cluster details)
+    print_warning "To add your clusters, you need to:"
+    print_warning "1. Ensure you have kubeconfig files for main and prod clusters"
+    print_warning "2. Update the cluster details in this script"
+    print_warning "3. Run the add_cluster_to_argocd function for each cluster"
+    
+    # Example of how to add clusters (uncomment and modify as needed):
+    # add_cluster_to_argocd "main" "https://main-cluster-server:6443" "/path/to/main-kubeconfig"
+    # add_cluster_to_argocd "prod" "https://prod-cluster-server:6443" "/path/to/prod-kubeconfig"
+    
+    # List clusters
+    list_argocd_clusters
+    
+    # Cleanup
+    print_status "Cleaning up port forwarding..."
+    kill $PORT_FORWARD_PID 2>/dev/null || true
+    
+    print_success "Process completed!"
+}
+
+# Run main function
+main "$@"

--- a/add-specific-clusters.sh
+++ b/add-specific-clusters.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# Specific script to add main and prod clusters to ArgoCD
+# This script provides step-by-step instructions for adding clusters
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to add a cluster using kubeconfig file
+add_cluster_with_kubeconfig() {
+    local cluster_name=$1
+    local kubeconfig_path=$2
+    local cluster_server=$3
+    
+    print_status "Adding cluster '$cluster_name' using kubeconfig: $kubeconfig_path"
+    
+    # Validate kubeconfig file exists
+    if [ ! -f "$kubeconfig_path" ]; then
+        print_error "Kubeconfig file not found: $kubeconfig_path"
+        return 1
+    fi
+    
+    # Add cluster to ArgoCD
+    argocd cluster add $cluster_name --kubeconfig $kubeconfig_path --server $cluster_server --yes || {
+        print_error "Failed to add cluster '$cluster_name'"
+        return 1
+    }
+    
+    print_success "Successfully added cluster '$cluster_name'"
+}
+
+# Function to add a cluster using context name
+add_cluster_with_context() {
+    local cluster_name=$1
+    local context_name=$2
+    
+    print_status "Adding cluster '$cluster_name' using context: $context_name"
+    
+    # Switch to the context
+    kubectl config use-context $context_name || {
+        print_error "Failed to switch to context: $context_name"
+        return 1
+    }
+    
+    # Add cluster to ArgoCD
+    argocd cluster add $cluster_name --yes || {
+        print_error "Failed to add cluster '$cluster_name'"
+        return 1
+    }
+    
+    print_success "Successfully added cluster '$cluster_name'"
+}
+
+# Function to setup ArgoCD connection
+setup_argocd_connection() {
+    local namespace=${1:-argocd}
+    
+    print_status "Setting up ArgoCD connection..."
+    
+    # Check if ArgoCD is running
+    if ! kubectl get pods -n $namespace | grep -q "argocd-server.*Running"; then
+        print_error "ArgoCD server is not running in namespace: $namespace"
+        print_status "Please ensure ArgoCD is installed and running"
+        return 1
+    fi
+    
+    # Get admin password
+    ARGOCD_PASSWORD=$(kubectl -n $namespace get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+    
+    if [ -z "$ARGOCD_PASSWORD" ]; then
+        print_error "Could not retrieve ArgoCD admin password"
+        return 1
+    fi
+    
+    print_success "ArgoCD admin password retrieved"
+    
+    # Setup port forwarding
+    print_status "Setting up port forwarding for ArgoCD server..."
+    kubectl port-forward svc/argocd-server -n $namespace 8080:443 &
+    PORT_FORWARD_PID=$!
+    
+    # Wait for port forwarding
+    sleep 5
+    
+    # Login to ArgoCD
+    argocd login localhost:8080 --username admin --password $ARGOCD_PASSWORD --insecure || {
+        print_error "Failed to login to ArgoCD"
+        kill $PORT_FORWARD_PID 2>/dev/null
+        return 1
+    }
+    
+    print_success "Successfully connected to ArgoCD"
+    echo $PORT_FORWARD_PID
+}
+
+# Main function
+main() {
+    print_status "Starting cluster addition process..."
+    
+    # Setup ArgoCD connection
+    PORT_FORWARD_PID=$(setup_argocd_connection)
+    
+    # Method 1: Using kubeconfig files
+    print_status "Method 1: Using kubeconfig files"
+    print_warning "If you have kubeconfig files for your clusters, place them in:"
+    print_warning "  - /workspace/clusters/main/kubeconfig"
+    print_warning "  - /workspace/clusters/prod/kubeconfig"
+    print_warning "Then uncomment and run the following commands:"
+    echo ""
+    echo "# add_cluster_with_kubeconfig 'main' '/workspace/clusters/main/kubeconfig' 'https://main-cluster-server:6443'"
+    echo "# add_cluster_with_kubeconfig 'prod' '/workspace/clusters/prod/kubeconfig' 'https://prod-cluster-server:6443'"
+    echo ""
+    
+    # Method 2: Using kubectl contexts
+    print_status "Method 2: Using kubectl contexts"
+    print_warning "If you have kubectl contexts configured, you can use:"
+    echo ""
+    echo "# add_cluster_with_context 'main' 'main-cluster-context'"
+    echo "# add_cluster_with_context 'prod' 'prod-cluster-context'"
+    echo ""
+    
+    # Method 3: Manual addition
+    print_status "Method 3: Manual addition using ArgoCD CLI"
+    print_warning "You can also add clusters manually using:"
+    echo ""
+    echo "argocd cluster add <cluster-name> --kubeconfig <path-to-kubeconfig>"
+    echo ""
+    
+    # List current clusters
+    print_status "Current clusters in ArgoCD:"
+    argocd cluster list
+    
+    # Cleanup
+    print_status "Cleaning up..."
+    kill $PORT_FORWARD_PID 2>/dev/null || true
+    
+    print_success "Setup complete! Please follow the instructions above to add your clusters."
+}
+
+# Run main function
+main "$@"

--- a/example-cluster-configs.yaml
+++ b/example-cluster-configs.yaml
@@ -1,0 +1,81 @@
+# Example cluster configurations for ArgoCD
+# These are examples - replace with your actual cluster details
+
+---
+# Example: Main cluster configuration
+apiVersion: v1
+kind: Secret
+metadata:
+  name: main-cluster-secret
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: main
+  server: https://main-cluster-server:6443
+  config: |
+    {
+      "bearerToken": "your-main-cluster-token-here",
+      "tlsClientConfig": {
+        "insecure": false,
+        "caData": "your-main-cluster-ca-data-here"
+      }
+    }
+
+---
+# Example: Prod cluster configuration
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-cluster-secret
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: prod
+  server: https://prod-cluster-server:6443
+  config: |
+    {
+      "bearerToken": "your-prod-cluster-token-here",
+      "tlsClientConfig": {
+        "insecure": false,
+        "caData": "your-prod-cluster-ca-data-here"
+      }
+    }
+
+---
+# Example: Service account for ArgoCD on target clusters
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-manager
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-manager
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-manager
+subjects:
+- kind: ServiceAccount
+  name: argocd-manager
+  namespace: kube-system

--- a/manual-cluster-addition.md
+++ b/manual-cluster-addition.md
@@ -1,0 +1,194 @@
+# Manual Cluster Addition to ArgoCD
+
+Since the automated scripts may have limitations, here's a manual step-by-step guide to add your main and prod clusters to ArgoCD.
+
+## Prerequisites
+
+1. ArgoCD installed and running on dev cluster
+2. Access to main and prod cluster kubeconfig files
+3. kubectl and ArgoCD CLI installed
+
+## Step 1: Verify ArgoCD is Running
+
+```bash
+kubectl get pods -n argocd
+```
+
+You should see pods like:
+- argocd-server
+- argocd-application-controller
+- argocd-dex-server
+- argocd-redis
+- argocd-repo-server
+
+## Step 2: Get ArgoCD Admin Password
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+```
+
+Copy this password - you'll need it to login to ArgoCD.
+
+## Step 3: Setup Port Forwarding
+
+In one terminal, run:
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+Keep this terminal running.
+
+## Step 4: Login to ArgoCD
+
+In another terminal, run:
+```bash
+argocd login localhost:8080 --username admin --password <your-password> --insecure
+```
+
+Replace `<your-password>` with the password from Step 2.
+
+## Step 5: Add Main Cluster
+
+### Option A: Using Kubeconfig File
+
+If you have a kubeconfig file for your main cluster:
+
+```bash
+argocd cluster add main --kubeconfig /path/to/main-kubeconfig --server https://main-cluster-server:6443
+```
+
+### Option B: Using Kubectl Context
+
+If you have a kubectl context for your main cluster:
+
+```bash
+# Switch to main cluster context
+kubectl config use-context main-cluster-context
+
+# Add main cluster
+argocd cluster add main
+```
+
+## Step 6: Add Prod Cluster
+
+### Option A: Using Kubeconfig File
+
+If you have a kubeconfig file for your prod cluster:
+
+```bash
+argocd cluster add prod --kubeconfig /path/to/prod-kubeconfig --server https://prod-cluster-server:6443
+```
+
+### Option B: Using Kubectl Context
+
+If you have a kubectl context for your prod cluster:
+
+```bash
+# Switch to prod cluster context
+kubectl config use-context prod-cluster-context
+
+# Add prod cluster
+argocd cluster add prod
+```
+
+## Step 7: Verify Clusters
+
+List all clusters in ArgoCD:
+
+```bash
+argocd cluster list
+```
+
+You should see:
+- dev (in-cluster)
+- main
+- prod
+
+## Step 8: Test Cluster Access
+
+Test that ArgoCD can access your clusters:
+
+```bash
+# Test main cluster
+argocd cluster get main
+
+# Test prod cluster
+argocd cluster get prod
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"cluster not accessible"**: Check that the cluster server URL is correct and accessible
+2. **"authentication failed"**: Verify the kubeconfig file has valid credentials
+3. **"permission denied"**: Ensure the service account has proper RBAC permissions
+
+### RBAC Setup on Target Clusters
+
+For ArgoCD to manage applications on your clusters, you need to create a service account with proper permissions on each target cluster (main and prod).
+
+Apply this configuration to your main and prod clusters:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-manager
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-manager
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-manager
+subjects:
+- kind: ServiceAccount
+  name: argocd-manager
+  namespace: kube-system
+```
+
+## Next Steps
+
+After successfully adding your clusters:
+
+1. Create applications that can be deployed to different clusters
+2. Set up cluster-specific configurations
+3. Configure cluster-specific policies and constraints
+4. Set up monitoring and logging for multi-cluster deployments
+
+## Useful Commands
+
+```bash
+# List all clusters
+argocd cluster list
+
+# Get cluster details
+argocd cluster get <cluster-name>
+
+# Remove a cluster
+argocd cluster rm <cluster-name>
+
+# List applications
+argocd app list
+
+# Create an application
+argocd app create <app-name> --repo <repo-url> --path <path> --dest-server <cluster-url> --dest-namespace <namespace>
+```

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Quick start script for adding clusters to ArgoCD
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== ArgoCD Cluster Addition Quick Start ===${NC}"
+echo ""
+
+# Check if we're connected to a cluster
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo -e "${YELLOW}Warning: Not connected to any Kubernetes cluster${NC}"
+    echo "Please ensure you're connected to your dev cluster where ArgoCD is installed"
+    echo ""
+fi
+
+# Check ArgoCD status
+echo -e "${BLUE}Checking ArgoCD status...${NC}"
+if kubectl get pods -n argocd | grep -q "argocd-server.*Running"; then
+    echo -e "${GREEN}✓ ArgoCD is running${NC}"
+else
+    echo -e "${YELLOW}⚠ ArgoCD server is not running. Please check your ArgoCD installation.${NC}"
+    echo "Run: kubectl get pods -n argocd"
+    exit 1
+fi
+
+# Get ArgoCD admin password
+echo -e "${BLUE}Getting ArgoCD admin password...${NC}"
+ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d 2>/dev/null)
+
+if [ -z "$ARGOCD_PASSWORD" ]; then
+    echo -e "${YELLOW}⚠ Could not retrieve ArgoCD admin password${NC}"
+    echo "Please check if ArgoCD is properly installed"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ ArgoCD admin password retrieved${NC}"
+echo "Admin password: $ARGOCD_PASSWORD"
+echo ""
+
+# Setup port forwarding
+echo -e "${BLUE}Setting up port forwarding...${NC}"
+kubectl port-forward svc/argocd-server -n argocd 8080:443 &
+PORT_FORWARD_PID=$!
+
+# Wait for port forwarding
+sleep 5
+
+# Login to ArgoCD
+echo -e "${BLUE}Logging into ArgoCD...${NC}"
+argocd login localhost:8080 --username admin --password $ARGOCD_PASSWORD --insecure
+
+echo -e "${GREEN}✓ Successfully connected to ArgoCD${NC}"
+echo ""
+
+# Show current clusters
+echo -e "${BLUE}Current clusters in ArgoCD:${NC}"
+argocd cluster list
+echo ""
+
+# Instructions for adding clusters
+echo -e "${YELLOW}To add your main and prod clusters, you can:${NC}"
+echo ""
+echo "1. Using kubeconfig files:"
+echo "   argocd cluster add main --kubeconfig /path/to/main-kubeconfig --server https://main-cluster:6443"
+echo "   argocd cluster add prod --kubeconfig /path/to/prod-kubeconfig --server https://prod-cluster:6443"
+echo ""
+echo "2. Using kubectl contexts:"
+echo "   kubectl config use-context main-cluster-context"
+echo "   argocd cluster add main"
+echo "   kubectl config use-context prod-cluster-context"
+echo "   argocd cluster add prod"
+echo ""
+
+# Cleanup
+echo -e "${BLUE}Cleaning up port forwarding...${NC}"
+kill $PORT_FORWARD_PID 2>/dev/null || true
+
+echo -e "${GREEN}✓ Setup complete!${NC}"
+echo "You can now add your clusters using the commands above."

--- a/verify-clusters.sh
+++ b/verify-clusters.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Script to verify clusters in ArgoCD
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== ArgoCD Cluster Verification ===${NC}"
+echo ""
+
+# Check if we're connected to a cluster
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo -e "${RED}Error: Not connected to any Kubernetes cluster${NC}"
+    exit 1
+fi
+
+# Check ArgoCD status
+echo -e "${BLUE}Checking ArgoCD status...${NC}"
+if kubectl get pods -n argocd | grep -q "argocd-server.*Running"; then
+    echo -e "${GREEN}✓ ArgoCD is running${NC}"
+else
+    echo -e "${RED}✗ ArgoCD server is not running${NC}"
+    echo "Please check your ArgoCD installation"
+    exit 1
+fi
+
+# Setup port forwarding
+echo -e "${BLUE}Setting up port forwarding...${NC}"
+kubectl port-forward svc/argocd-server -n argocd 8080:443 &
+PORT_FORWARD_PID=$!
+
+# Wait for port forwarding
+sleep 5
+
+# Get ArgoCD admin password
+echo -e "${BLUE}Getting ArgoCD admin password...${NC}"
+ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d 2>/dev/null)
+
+if [ -z "$ARGOCD_PASSWORD" ]; then
+    echo -e "${RED}✗ Could not retrieve ArgoCD admin password${NC}"
+    kill $PORT_FORWARD_PID 2>/dev/null
+    exit 1
+fi
+
+# Login to ArgoCD
+echo -e "${BLUE}Logging into ArgoCD...${NC}"
+argocd login localhost:8080 --username admin --password $ARGOCD_PASSWORD --insecure
+
+echo -e "${GREEN}✓ Successfully connected to ArgoCD${NC}"
+echo ""
+
+# List clusters
+echo -e "${BLUE}Clusters in ArgoCD:${NC}"
+argocd cluster list
+echo ""
+
+# Check each cluster
+echo -e "${BLUE}Checking cluster connectivity...${NC}"
+
+# Get cluster list
+CLUSTERS=$(argocd cluster list -o name | sed 's/cluster\.argoproj\.io\///')
+
+for cluster in $CLUSTERS; do
+    echo -e "${BLUE}Checking cluster: $cluster${NC}"
+    if argocd cluster get $cluster >/dev/null 2>&1; then
+        echo -e "${GREEN}✓ $cluster is accessible${NC}"
+    else
+        echo -e "${RED}✗ $cluster is not accessible${NC}"
+    fi
+done
+
+# Cleanup
+echo -e "${BLUE}Cleaning up...${NC}"
+kill $PORT_FORWARD_PID 2>/dev/null || true
+
+echo -e "${GREEN}✓ Verification complete!${NC}"


### PR DESCRIPTION
Add scripts and documentation to integrate main and prod Kubernetes clusters with an existing ArgoCD instance.

This PR provides automated scripts, manual guides, and example configurations to help users add external clusters to their ArgoCD setup, supporting both kubeconfig files and kubectl contexts for cluster registration.

---
<a href="https://cursor.com/background-agent?bcId=bc-74f2d3c5-0808-4245-91dc-f2404cc7ed57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74f2d3c5-0808-4245-91dc-f2404cc7ed57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

